### PR TITLE
Replace <C-C><C-C> with <C-C>

### DIFF
--- a/tests/test_vimgolf.py
+++ b/tests/test_vimgolf.py
@@ -109,7 +109,7 @@ class TestVimgolf(unittest.TestCase):
             PlaySpec('hello world', 'hello', 'A<bs><bs><bs><bs><bs><esc>ZZ', False),
             PlaySpec('hello world', 'hllo world', '<space><Space>i<bs><Esc>XZZ', True),
             PlaySpec('hello world', 'hello\n\\|world', 'WXi<enter><bslash><BAR><Esc>ZZ', True),
-            # Make sure double <c-c>, specified as init keys, doesn't get dropped (the score
+            # Make sure double <c-c>, specified as init keys, doesn't get replaced (the score
             # should be 4, which is tested).
             PlaySpec('', 'hello world', '<c-c><c-c>ZZ', False),
         ]

--- a/vimgolf/keys.py
+++ b/vimgolf/keys.py
@@ -68,6 +68,22 @@ def parse_keycodes(raw_keys):
     return keycodes
 
 
+def replace_double_ctrl_c(parsed_keycodes, start=0):
+    """
+    Replace double entries of b'\x00\x03' (<c-c>) with a single entry,
+    starting at the specified location.
+    """
+    idx = start + 1
+    skip = set()
+    while idx < len(parsed_keycodes):
+        if parsed_keycodes[idx] == parsed_keycodes[idx - 1] == b'\x00\x03':
+            skip.add(idx)
+            idx += 1
+        idx += 1
+    keycodes = [x for idx, x in enumerate(parsed_keycodes) if idx not in skip]
+    return keycodes
+
+
 # keystrokes that should not impact score (e.g., window focus)
 IGNORED_KEYSTROKES = {
     b'\xfd\x35', # (35) KE_IGNORE

--- a/vimgolf/vimgolf.py
+++ b/vimgolf/vimgolf.py
@@ -530,7 +530,8 @@ def play(challenge, results=None):
 
             # list of parsed keycode byte strings
             keycodes = parse_keycodes(raw_keys)
-            # Drop <c-c><c-c> (Vim #11541). Skip the init keys, since the issue is not present for feedkeys().
+            # Replace <C-C><C-C> with <C-C> (Vim #11541). Skip the init keys, since the issue is not
+            # present for feedkeys().
             keycodes = replace_double_ctrl_c(keycodes, len(init_reprs))
             keycodes = [keycode for keycode in keycodes if keycode not in IGNORED_KEYSTROKES]
 

--- a/vimgolf/vimgolf.py
+++ b/vimgolf/vimgolf.py
@@ -26,6 +26,7 @@ from vimgolf.html import (
     parse_html,
 )
 from vimgolf.keys import (
+    replace_double_ctrl_c,
     get_keycode_repr,
     IGNORED_KEYSTROKES,
     parse_keycodes,
@@ -484,9 +485,9 @@ def play(challenge, results=None):
             # while the script read with "-s scriptin" expects escape codes").
             # The conversion is conducted here so that we can fail fast on
             # error (prior to playing) and to avoid repeated computation.
-            keycode_reprs = tokenize_keycode_reprs(challenge.init_keys)
+            init_reprs = tokenize_keycode_reprs(challenge.init_keys)
             init_feedkeys = []
-            for item in keycode_reprs:
+            for item in init_reprs:
                 if item == '\\':
                     item = '\\\\'  # Replace '\' with '\\'
                 elif item == '"':
@@ -529,6 +530,8 @@ def play(challenge, results=None):
 
             # list of parsed keycode byte strings
             keycodes = parse_keycodes(raw_keys)
+            # Drop <c-c><c-c> (Vim #11541). Skip the init keys, since the issue is not present for feedkeys().
+            keycodes = replace_double_ctrl_c(keycodes, len(init_reprs))
             keycodes = [keycode for keycode in keycodes if keycode not in IGNORED_KEYSTROKES]
 
             # list of human-readable key strings


### PR DESCRIPTION
Vim intentionally replaces `<C-C>` with `<C-C><C-C>`, which is reflected in the output when using `-W` (https://github.com/vim/vim/issues/11541).

In VimGolf, when a user enters `<C-C>`, the input will count as two keystrokes towards the score, showing `<C-C>` twice in the displayed keystrokes.

This PR updates the code to replace `<C-C><C-C>` with `<C-C>`.