### PR TITLE
Anti-cheating

### DIFF
--- a/vimgolf/vimgolf.py
+++ b/vimgolf/vimgolf.py
@@ -531,7 +531,8 @@ def play(challenge, results=None):
         while True:
             with open(infile, 'w') as f:
                 f.write(challenge.in_text)
-
+            with open(outfile, 'w') as f:
+                f.write(challenge.out_text)
             vimrc = os.path.join(os.path.dirname(__file__), 'vimgolf.vimrc')
             play_args = [
                 '-Z',           # restricted mode, utilities not allowed
@@ -587,6 +588,10 @@ def play(challenge, results=None):
             while True:
                 # Generate the menu items inside the loop since it can change across iterations
                 # (e.g., upload option can be removed)
+                with open(infile, 'w') as f:
+                    f.write(challenge.in_text)
+                with open(outfile, 'w') as f:
+                    f.write(challenge.out_text)
                 menu = []
                 if not correct:
                     menu.append(('d', 'Show diff'))


### PR DESCRIPTION
User can change the outfile in the previous version.

With this modification, the outfile will be reset on every dialog.

---

Additionally, about why `nvim` needs `os.system('')` hack on windows, I think it is for enabling ANSI virtual terminal.

Explanation on [stackoverflow](https://stackoverflow.com/questions/16755142/how-to-make-win32-console-recognize-ansi-vt100-escape-sequences-in-c/39675059#39675059)